### PR TITLE
docs: update readme update after releasing v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ provider "postgresql" {
 }
 
 module "postgres_automation" {
-  source = "git::https://github.com/masterpointio/terraform-postgres-config-dbs-users-roles.git?ref=main"
+  source  = "masterpointio/config-dbs-users-roles/postgres"
+  version = "X.X.X"
 
   databases = [
     {


### PR DESCRIPTION
## what
- update readme with terraform registry ref

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example Terraform module source in the README to use the Terraform Registry format with a version attribute instead of a direct Git URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->